### PR TITLE
Implement TUI auto-reconnect

### DIFF
--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -39,7 +39,7 @@ struct App {
 impl App {
     async fn run(&mut self, port: Port, term: &mut DefaultTerminal) -> Result<()> {
         let mut events = EventStream::new();
-        let (mut rx, mut worker) = Worker::start(port);
+        let mut rx = Worker::start(port);
 
         while !self.should_exit {
             // Draw terminal widgets
@@ -60,7 +60,6 @@ impl App {
                 Some(resp) = rx.recv() => self
                     .handle_worker_response(resp)
                     .context("Failed to handle worker response")?,
-                res = &mut worker => res?.context("Failed to run worker")?,
             }
         }
 
@@ -101,6 +100,7 @@ impl App {
             } => {
                 self.session = Some(Session::create(software_id, kind, actions, tx)?);
             }
+            Response::DeviceDisconnected => self.session = None,
             _ => {
                 if let Some(sess) = &mut self.session {
                     sess.handle_worker_response(resp)?;

--- a/tui/src/session.rs
+++ b/tui/src/session.rs
@@ -104,7 +104,6 @@ impl Session {
 
     pub fn handle_worker_response(&mut self, resp: Response) -> Result<()> {
         match resp {
-            Response::DeviceConnected { .. } => {}
             Response::PropertiesQueried(kind, data) => {
                 if let Some((_, table)) = self.tables.iter_mut().find(|(k, _)| k == &kind) {
                     table.update(data);
@@ -118,6 +117,7 @@ impl Session {
             Response::InvalidActionState(action) => {
                 self.popup = Some(Popup::InvalidActionState(action));
             }
+            _ => {}
         }
 
         Ok(())

--- a/tui/src/worker.rs
+++ b/tui/src/worker.rs
@@ -3,9 +3,10 @@ use freemdu::{
     device::{self, Action, DeviceKind, Error, Property, PropertyKind, Value},
     serial::Port,
 };
+use log::debug;
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
-    task::{self, JoinHandle},
+    task,
     time::{self, Duration},
 };
 
@@ -31,6 +32,7 @@ pub enum Response {
         actions: &'static [Action],
         tx: UnboundedSender<Request>,
     },
+    DeviceDisconnected,
     PropertiesQueried(PropertyKind, Vec<(&'static Property, Value)>),
     InvalidActionArgument(&'static Action),
     InvalidActionState(&'static Action),
@@ -38,46 +40,62 @@ pub enum Response {
 
 pub struct Worker<'a> {
     dev: Device<'a>,
-    tx: UnboundedSender<Response>,
+    tx: &'a UnboundedSender<Response>,
 }
 
 impl Worker<'_> {
-    pub fn start(mut port: Port) -> (UnboundedReceiver<Response>, JoinHandle<Result<()>>) {
+    pub fn start(mut port: Port) -> UnboundedReceiver<Response> {
         let (tx, rx) = mpsc::unbounded_channel();
-        let handle = task::spawn_local(async move {
+
+        task::spawn_local(async move {
             loop {
-                // Connect to device (retry on timeout)
+                // Automatically reconnect in case of failure
                 match time::timeout(DEVICE_TIMEOUT, device::connect(&mut port)).await {
-                    Ok(dev) => return Worker { dev: dev?, tx }.run().await,
-                    Err(_) => time::sleep(DEVICE_CONNECT_INTERVAL).await,
+                    Ok(Ok(dev)) => {
+                        let mut worker = Worker { dev, tx: &tx };
+
+                        if let Err(err) = worker.run().await {
+                            debug!("Error running device worker: {err:#}");
+                        }
+                    }
+                    Ok(Err(err)) => debug!("Error connecting to device: {err:#}"),
+                    Err(_) => debug!("Device connection timed out"),
                 }
+
+                time::sleep(DEVICE_CONNECT_INTERVAL).await;
             }
         });
 
-        (rx, handle)
+        rx
     }
 
     async fn run(&mut self) -> Result<()> {
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (dev_tx, mut dev_rx) = mpsc::unbounded_channel();
 
         self.tx.send(Response::DeviceConnected {
             software_id: self.dev.software_id(),
             kind: self.dev.kind(),
             actions: self.dev.actions(),
-            tx,
+            tx: dev_tx,
         })?;
 
-        // Handle incoming commands from session channel
-        while let Some(cmd) = rx.recv().await {
-            match cmd {
+        // Handle incoming commands from device channel
+        while let Some(cmd) = dev_rx.recv().await {
+            let res = match cmd {
                 Request::QueryProperties(kind) => self
                     .query_properties(kind)
                     .await
-                    .context("Failed to query properties")?,
+                    .context("Failed to query properties"),
                 Request::TriggerAction(action, param) => self
                     .trigger_action(action, param)
                     .await
-                    .context("Failed to trigger action")?,
+                    .context("Failed to trigger action"),
+            };
+
+            if res.is_err() {
+                self.tx.send(Response::DeviceDisconnected)?;
+
+                return res;
             }
         }
 


### PR DESCRIPTION
This PR implements an auto-reconnect feature for the TUI.

If a device communication error occurs (e.g. disconnect, incorrect checksum, etc.), the TUI transitions back to the "Waiting for device connection..." state and attempts to establish a new connection after 4 seconds.

@ThiefMaster It would be great if you could give this a quick test on your W 980.

Resolves #23